### PR TITLE
fix rake install

### DIFF
--- a/README
+++ b/README
@@ -1,13 +1,11 @@
 Just a playground. Not for production use.
 
 How to try it:
-install rubygem-ruby-augeas from OBS
-    sudo zypper ar http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/openSUSE_11.4/ rubyext
-    sudo zypper in rubygem-ruby-augeas
-install rubygem-open4
-    sudo zypper in rubygem-open4
-install rubygem-packaging-rake-tasks
-    sudo zypper in rubygem-packaging-rake-tasks
+install rubygem dependencies from the OpenSUSE build system's Ruby Extensions repository:
+
+    sudo zypper ar http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/openSUSE_11.4/devel:languages:ruby:extensions.repo
+    sudo zypper in rubygem-ruby-augeas rubygem-open4 rubygem-packaging-rake-tasks rubygem-ruby-dbus
+
 sudo rake install
 cd yast++lib-kerberos-client
 ruby examples/kerberos_conf

--- a/config_agent-country/Rakefile
+++ b/config_agent-country/Rakefile
@@ -22,7 +22,7 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  args.with_defaults :prefix => '/',:ruby_path => "usr/lib*/ruby/vendor_ruby/1.*/"
+  args.with_defaults :prefix => '/',:ruby_path => Dir["#{args[:prefix]}/usr/lib*/ruby/vendor_ruby/1.*/"][0]
   sh "mkdir -p #{args[:prefix]}etc/dbus-1/system.d/"
   sh "cp -r infrastructure/dbus-policies/* #{args[:prefix]}etc/dbus-1/system.d/"
   sh "mkdir -p #{args[:prefix]}usr/share/dbus-1/system-services/"

--- a/config_agent-country/Rakefile
+++ b/config_agent-country/Rakefile
@@ -22,7 +22,7 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  args.with_defaults :prefix => '/',:ruby_path => Dir["#{args[:prefix]}/usr/lib*/ruby/vendor_ruby/1.*/"][0]
+  args.with_defaults :prefix => '/',:ruby_path => Dir["/usr/lib*/ruby/vendor_ruby/1.*/"][0]
   sh "mkdir -p #{args[:prefix]}etc/dbus-1/system.d/"
   sh "cp -r infrastructure/dbus-policies/* #{args[:prefix]}etc/dbus-1/system.d/"
   sh "mkdir -p #{args[:prefix]}usr/share/dbus-1/system-services/"

--- a/config_agent-country/Rakefile
+++ b/config_agent-country/Rakefile
@@ -33,7 +33,7 @@ task :install, :prefix, :ruby_path do |t,args|
   sh "cp -r infrastructure/bin services #{args[:prefix]}usr/share/config_agents/"
   sh "mkdir -p #{args[:prefix]}usr/share/polkit-1/actions/"
   sh "cp infrastructure/polkit-definitions/* #{args[:prefix]}usr/share/polkit-1/actions/"
-  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/" if Dir["#{args[:prefix]}#{args[:ruby_path]}/"].empty?
+  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/"
   sh "cd #{args[:prefix]}#{args[:ruby_path]}/; mkdir -p config_agent; cd -"
   sh "cp -r infrastructure/clients/config_agent #{args[:prefix]}usr/lib*/ruby/vendor_ruby/1.*/"
   sh "chmod +x #{args[:prefix]}usr/share/config_agents/bin/*/*.rb"

--- a/config_agent-kerberos/Rakefile
+++ b/config_agent-kerberos/Rakefile
@@ -22,7 +22,7 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  args.with_defaults :prefix => '/',:ruby_path => "usr/lib*/ruby/vendor_ruby/1.*/"
+  args.with_defaults :prefix => '/',:ruby_path => Dir["usr/lib*/ruby/vendor_ruby/1.*/"][0]
   sh "mkdir -p #{args[:prefix]}etc/dbus-1/system.d/"
   sh "cp -r infrastructure/dbus-policies/* #{args[:prefix]}etc/dbus-1/system.d/"
   sh "mkdir -p #{args[:prefix]}usr/share/dbus-1/system-services/"

--- a/config_agent-kerberos/Rakefile
+++ b/config_agent-kerberos/Rakefile
@@ -22,7 +22,7 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  args.with_defaults :prefix => '/',:ruby_path => Dir["usr/lib*/ruby/vendor_ruby/1.*/"][0]
+  args.with_defaults :prefix => '/',:ruby_path => Dir["/usr/lib*/ruby/vendor_ruby/1.*/"][0]
   sh "mkdir -p #{args[:prefix]}etc/dbus-1/system.d/"
   sh "cp -r infrastructure/dbus-policies/* #{args[:prefix]}etc/dbus-1/system.d/"
   sh "mkdir -p #{args[:prefix]}usr/share/dbus-1/system-services/"

--- a/config_agent-pam/Rakefile
+++ b/config_agent-pam/Rakefile
@@ -22,7 +22,7 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  args.with_defaults :prefix => '/',:ruby_path => "usr/lib*/ruby/vendor_ruby/1.*/"
+  args.with_defaults :prefix => '/',:ruby_path => Dir["/usr/lib*/ruby/vendor_ruby/1.*/"][0]
   sh "mkdir -p #{args[:prefix]}etc/dbus-1/system.d/"
   sh "cp -r infrastructure/dbus-policies/* #{args[:prefix]}etc/dbus-1/system.d/"
   sh "mkdir -p #{args[:prefix]}usr/share/dbus-1/system-services/"

--- a/config_agent-pam/Rakefile
+++ b/config_agent-pam/Rakefile
@@ -31,7 +31,7 @@ task :install, :prefix, :ruby_path do |t,args|
   sh "cp -r infrastructure/bin services #{args[:prefix]}usr/share/config_agents/"
   sh "mkdir -p #{args[:prefix]}usr/share/polkit-1/actions/"
   sh "cp infrastructure/polkit-definitions/* #{args[:prefix]}usr/share/polkit-1/actions/"
-  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/" if Dir["#{args[:prefix]}#{args[:ruby_path]}/"].empty?
+  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/"
   sh "cd #{args[:prefix]}#{args[:ruby_path]}/; mkdir -p config_agent; cd -"
   sh "cp -r infrastructure/clients/config_agent #{args[:prefix]}usr/lib*/ruby/vendor_ruby/1.*/"
   sh "chmod +x #{args[:prefix]}usr/share/config_agents/bin/*/*.rb"

--- a/libconfigagent/Rakefile
+++ b/libconfigagent/Rakefile
@@ -21,9 +21,9 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  args.with_defaults :prefix => '/',:ruby_path => "usr/lib*/ruby/vendor_ruby/1.*/"
   sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/dbus_clients" if Dir["#{args[:prefix]}#{args[:ruby_path]}/dbus_clients"].empty?
   sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/dbus_services" if Dir["#{args[:prefix]}#{args[:ruby_path]}/dbus_services"].empty?
+  args.with_defaults :prefix => '/',:ruby_path => Dir["/usr/lib*/ruby/vendor_ruby/1.*/"][0]
   sh "cp dbus_clients/* #{args[:prefix]}#{args[:ruby_path]}/dbus_clients"
   sh "cp dbus_services/* #{args[:prefix]}#{args[:ruby_path]}/dbus_services"
   sh "mkdir -p #{args[:prefix]}usr/lib/config-agent-generator"

--- a/libconfigagent/Rakefile
+++ b/libconfigagent/Rakefile
@@ -21,9 +21,9 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/dbus_clients" if Dir["#{args[:prefix]}#{args[:ruby_path]}/dbus_clients"].empty?
-  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/dbus_services" if Dir["#{args[:prefix]}#{args[:ruby_path]}/dbus_services"].empty?
   args.with_defaults :prefix => '/',:ruby_path => Dir["/usr/lib*/ruby/vendor_ruby/1.*/"][0]
+  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/dbus_clients"
+  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/dbus_services"
   sh "cp dbus_clients/* #{args[:prefix]}#{args[:ruby_path]}/dbus_clients"
   sh "cp dbus_services/* #{args[:prefix]}#{args[:ruby_path]}/dbus_services"
   sh "mkdir -p #{args[:prefix]}usr/lib/config-agent-generator"

--- a/libconfigagent/agent-generator/Rakefile.erb
+++ b/libconfigagent/agent-generator/Rakefile.erb
@@ -22,7 +22,7 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  args.with_defaults :prefix => '/',:ruby_path => "usr/lib*/ruby/vendor_ruby/1.*/"
+  args.with_defaults :prefix => '/',:ruby_path => Dir["/usr/lib*/ruby/vendor_ruby/1.*/"][0]
   sh "mkdir -p #{args[:prefix]}etc/dbus-1/system.d/"
   sh "cp -r infrastructure/dbus-policies/* #{args[:prefix]}etc/dbus-1/system.d/"
   sh "mkdir -p #{args[:prefix]}usr/share/dbus-1/system-services/"
@@ -31,7 +31,7 @@ task :install, :prefix, :ruby_path do |t,args|
   sh "cp -r infrastructure/bin services #{args[:prefix]}usr/share/config_agents/"
   sh "mkdir -p #{args[:prefix]}usr/share/polkit-1/actions/"
   sh "cp infrastructure/polkit-definitions/* #{args[:prefix]}usr/share/polkit-1/actions/"
-  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/" if Dir["#{args[:prefix]}#{args[:ruby_path]}/"].empty?
+  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/"
   sh "cd #{args[:prefix]}#{args[:ruby_path]}/; mkdir -p config_agent; cd -"
   sh "cp -r infrastructure/clients/config_agent #{args[:prefix]}usr/lib*/ruby/vendor_ruby/1.*/"
   sh "chmod +x #{args[:prefix]}usr/share/config_agents/bin/*/*.rb"

--- a/libconfigagent/libconfigagent.spec.template
+++ b/libconfigagent/libconfigagent.spec.template
@@ -11,8 +11,8 @@
 
 Name:           libconfigagent
 Requires:       rubygem-ruby-dbus
-License:	      LGPLv2.1 or LGPLv3
-Group:          Libraries/System
+License:        LGPLv2.1 or LGPLv3
+Group:          System/Libraries
 URL:            https://github.com/yast/yast--
 Autoreqprov:    on
 Version:        VERSION_TEMPLATE
@@ -21,6 +21,7 @@ Summary:        libconfigagent - framework for config agents
 Source:         libconfigagent-%{version}.tar.bz2
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildArch:      noarch
 BuildRequires:  ruby
 BuildRequires:  rubygem-packaging-rake-tasks
 
@@ -37,15 +38,17 @@ Summary:  Generator of new config agents
 
 
 %description
-libconfigagent - Framework needed by each config agent. Provide way to easy
-way to call agent attached to dbus in transparent way.
+Framework needed by each config agent. Provide way to easy way to call
+agent attached to dbus in transparent way.
+
 Authors:
 --------
     Josef Reidinger <jreidinger@suse.cz>
 
 %description devel
-Contain generator for new config agents. It generates neccessary dbus and polkit configartion,
-code which call proper parts of code and stubs for methods.
+Contain generator for new config agents. It generates neccessary dbus
+and polkit configuration, code which call proper parts of code and stubs
+for methods.
 
 %prep
 %setup

--- a/yast++lib-country/Rakefile
+++ b/yast++lib-country/Rakefile
@@ -22,7 +22,7 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  args.with_defaults :prefix => '/',:ruby_path => "usr/lib*/ruby/vendor_ruby/1.*"
+  args.with_defaults :prefix => '/',:ruby_path => ["/usr/lib*/ruby/vendor_ruby/1.*"][0]
   sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/" if Dir["#{args[:prefix]}#{args[:ruby_path]}/"].empty?
   sh "cd #{args[:prefix]}#{args[:ruby_path]}/; mkdir -p y_lib; cd -"
   sh "cp lib/y_lib/* #{args[:prefix]}#{args[:ruby_path]}/y_lib"

--- a/yast++lib-country/Rakefile
+++ b/yast++lib-country/Rakefile
@@ -22,7 +22,7 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  args.with_defaults :prefix => '/',:ruby_path => ["/usr/lib*/ruby/vendor_ruby/1.*"][0]
+  args.with_defaults :prefix => '/',:ruby_path => Dir["/usr/lib*/ruby/vendor_ruby/1.*"][0]
   sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/"
   sh "cd #{args[:prefix]}#{args[:ruby_path]}/; mkdir -p y_lib; cd -"
   sh "cp lib/y_lib/* #{args[:prefix]}#{args[:ruby_path]}/y_lib"

--- a/yast++lib-country/Rakefile
+++ b/yast++lib-country/Rakefile
@@ -23,7 +23,7 @@ require "packaging"
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
   args.with_defaults :prefix => '/',:ruby_path => ["/usr/lib*/ruby/vendor_ruby/1.*"][0]
-  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/" if Dir["#{args[:prefix]}#{args[:ruby_path]}/"].empty?
+  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/"
   sh "cd #{args[:prefix]}#{args[:ruby_path]}/; mkdir -p y_lib; cd -"
   sh "cp lib/y_lib/* #{args[:prefix]}#{args[:ruby_path]}/y_lib"
 end

--- a/yast++lib-kerberos-client/Rakefile
+++ b/yast++lib-kerberos-client/Rakefile
@@ -22,8 +22,8 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/" if Dir["#{args[:prefix]}#{args[:ruby_path]}/"].empty?
   args.with_defaults :prefix => '/',:ruby_path => Dir["/usr/lib*/ruby/vendor_ruby/1.*"][0]
+  sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/"
   sh "cd #{args[:prefix]}#{args[:ruby_path]}/; mkdir -p y_lib; cd -"
   sh "cp lib/y_lib/* #{args[:prefix]}#{args[:ruby_path]}/y_lib"
 end

--- a/yast++lib-kerberos-client/Rakefile
+++ b/yast++lib-kerberos-client/Rakefile
@@ -22,8 +22,8 @@ require "packaging"
 
 desc "install all things on system"
 task :install, :prefix, :ruby_path do |t,args|
-  args.with_defaults :prefix => '/',:ruby_path => "usr/lib*/ruby/vendor_ruby/1.*"
   sh "mkdir -p #{args[:prefix]}#{args[:ruby_path]}/" if Dir["#{args[:prefix]}#{args[:ruby_path]}/"].empty?
+  args.with_defaults :prefix => '/',:ruby_path => Dir["/usr/lib*/ruby/vendor_ruby/1.*"][0]
   sh "cd #{args[:prefix]}#{args[:ruby_path]}/; mkdir -p y_lib; cd -"
   sh "cp lib/y_lib/* #{args[:prefix]}#{args[:ruby_path]}/y_lib"
 end


### PR DESCRIPTION
Some packages were rake install-ing into /usr/lib*/ (with a literal star).

Made libconfigagent a noarch package because it's pure ruby.

Also edited README to mention a missing dependency on rubygem-ruby-dbus.
