### PR TITLE
Fix a missing require 'singleton' in dbus_clients/backend_exception

### DIFF
--- a/libconfigagent/dbus_clients/backend_exception.rb
+++ b/libconfigagent/dbus_clients/backend_exception.rb
@@ -16,6 +16,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #++
 
+require 'singleton'
+
 module DbusClients
   class ExceptionRegister
     include Singleton


### PR DESCRIPTION
require 'dbus_clients/backend_exception'
NameError: uninitialized constant DbusClients::ExceptionRegister::Singleton
    from /usr/lib/ruby/vendor_ruby/1.8/dbus_clients/backend_exception.rb:21
    from (irb):1:in `require'
    from (irb):1
    from :0
