### PR TITLE
Separated augeas and sysconfig.

### DIFF
--- a/config_agent-country/lib/config_agent/clock.rb
+++ b/config_agent-country/lib/config_agent/clock.rb
@@ -21,7 +21,8 @@ require 'config_agent/sysconfig'
 module ConfigAgent
   class Clock < ConfigAgent::Sysconfig
     def initialize params={}
-      super "/etc/sysconfig/clock",params
+      params[ :path] = "/etc/sysconfig/clock"
+      super( params)
     end
   end
 end

--- a/config_agent-country/lib/config_agent/keyboard.rb
+++ b/config_agent-country/lib/config_agent/keyboard.rb
@@ -21,7 +21,8 @@ require 'config_agent/sysconfig'
 module ConfigAgent
   class Keyboard < ConfigAgent::Sysconfig
     def initialize params={}
-      super "/etc/sysconfig/keyboard",params
+      params[ :path] = "/etc/sysconfig/keyboard" 
+      super( params )
     end
   end
 end

--- a/config_agent-country/lib/config_agent/language.rb
+++ b/config_agent-country/lib/config_agent/language.rb
@@ -21,7 +21,8 @@ require 'config_agent/sysconfig'
 module ConfigAgent
   class Language < ConfigAgent::Sysconfig
     def initialize params={}
-      super "/etc/sysconfig/language",params
+      params[ :path] = "/etc/sysconfig/language" 
+      super( params )
     end
   end
 end

--- a/config_agent-country/test/test_clock.rb
+++ b/config_agent-country/test/test_clock.rb
@@ -30,7 +30,7 @@ class TestClock < Test::Unit::TestCase
   end
 
   def test_reading
-    file = ConfigAgent::Clock.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file = ConfigAgent::Clock.new( :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     sysconfig_clock = file.read({})
     assert_equal "Europe/Prague", sysconfig_clock["TIMEZONE"]
     assert_equal "--localtime", sysconfig_clock["HWCLOCK"]
@@ -39,7 +39,7 @@ class TestClock < Test::Unit::TestCase
 
   # write new file
   def test_write
-    file = ConfigAgent::Clock.new( { :root_dir => @data1_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file = ConfigAgent::Clock.new( :root_dir => @data1_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     params	= {
 	"TIMEZONE"		=> "US/Eastern",
 	"HWCLOCK"		=> "-u"
@@ -51,11 +51,11 @@ class TestClock < Test::Unit::TestCase
 
   # diff data/etc/sysconfig/clock data2/etc/sysconfig/clock -> change value of TIMEZONE
   def test_overwrite
-    file = ConfigAgent::Clock.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file = ConfigAgent::Clock.new( :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     params = file.read({})
     assert_equal "Europe/Prague", params["TIMEZONE"]
 
-    file2 = ConfigAgent::Clock.new( { :root_dir => @data2_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file2 = ConfigAgent::Clock.new( :root_dir => @data2_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     params["TIMEZONE"]		= "US/Eastern"
 
     ret = file2.write params

--- a/config_agent-country/test/test_clock.rb
+++ b/config_agent-country/test/test_clock.rb
@@ -30,8 +30,8 @@ class TestClock < Test::Unit::TestCase
   end
 
   def test_reading
-    file = ConfigAgent::Clock.new
-    sysconfig_clock = file.read "_aug_internal" => Augeas::open(@data_dir, File.join(File.dirname(__FILE__),'..',"lens"),Augeas::NO_MODL_AUTOLOAD)
+    file = ConfigAgent::Clock.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    sysconfig_clock = file.read({})
     assert_equal "Europe/Prague", sysconfig_clock["TIMEZONE"]
     assert_equal "--localtime", sysconfig_clock["HWCLOCK"]
     assert_equal "yes", sysconfig_clock["SYSTOHC"]
@@ -39,25 +39,23 @@ class TestClock < Test::Unit::TestCase
 
   # write new file
   def test_write
-    file = ConfigAgent::Clock.new
+    file = ConfigAgent::Clock.new( { :root_dir => @data1_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
     params	= {
-	"_aug_internal"		=> Augeas::open(@data1_dir,nil, Augeas::NO_MODL_AUTOLOAD),
 	"TIMEZONE"		=> "US/Eastern",
 	"HWCLOCK"		=> "-u"
     }
     ret = file.write params
-    assert_equal true, ret["success"]
     assert_equal nil, ret["message"]
+    assert_equal true, ret["success"]
   end
 
   # diff data/etc/sysconfig/clock data2/etc/sysconfig/clock -> change value of TIMEZONE
   def test_overwrite
-    file = ConfigAgent::Clock.new
-    params = file.read "_aug_internal" => Augeas::open(@data_dir,nil, Augeas::NO_MODL_AUTOLOAD)
+    file = ConfigAgent::Clock.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    params = file.read({})
     assert_equal "Europe/Prague", params["TIMEZONE"]
 
-    file2 = ConfigAgent::Clock.new
-    params["_aug_internal"]	= Augeas::open(@data2_dir,nil, Augeas::NO_MODL_AUTOLOAD)
+    file2 = ConfigAgent::Clock.new( { :root_dir => @data2_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
     params["TIMEZONE"]		= "US/Eastern"
 
     ret = file2.write params

--- a/config_agent-country/test/test_keyboard.rb
+++ b/config_agent-country/test/test_keyboard.rb
@@ -30,8 +30,8 @@ class TestKeyboard < Test::Unit::TestCase
   end
 
   def test_reading
-    file = ConfigAgent::Keyboard.new
-    sysconfig_keyboard = file.read "_aug_internal" => Augeas::open(@data_dir, File.join(File.dirname(__FILE__),'..',"lens"),Augeas::NO_MODL_AUTOLOAD)
+    file = ConfigAgent::Keyboard.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    sysconfig_keyboard = file.read ({})
     assert_equal "english-us,pc104", sysconfig_keyboard["YAST_KEYBOARD"]
     assert_equal "us.map.gz", sysconfig_keyboard["KEYTABLE"]
     assert_equal "bios", sysconfig_keyboard["KBD_NUMLOCK"]
@@ -40,26 +40,24 @@ class TestKeyboard < Test::Unit::TestCase
 
   # write new file
   def test_write
-    file = ConfigAgent::Keyboard.new
+    file = ConfigAgent::Keyboard.new( { :root_dir => @data1_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
     params        = {
-        "_aug_internal"		=> Augeas::open(@data1_dir,nil, Augeas::NO_MODL_AUTOLOAD),
         "YAST_KEYBOARD"		=> "english-uk,pc104",
         "KEYTABLE"		=> "uk.map.gz"
     }
     ret = file.write params
-    assert_equal true, ret["success"]
     assert_equal nil, ret["message"]
+    assert_equal true, ret["success"]
   end
 
   # diff data/etc/sysconfig/keyboard data2/etc/sysconfig/keyboard -> change value of RC_LANG
   def test_overwrite
-    file = ConfigAgent::Keyboard.new
-    params = file.read "_aug_internal" => Augeas::open(@data_dir,nil, Augeas::NO_MODL_AUTOLOAD)
+    file = ConfigAgent::Keyboard.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    params = file.read({})
     assert_equal "english-us,pc104", params["YAST_KEYBOARD"]
     assert_equal "us.map.gz", params["KEYTABLE"]
 
-    file2 = ConfigAgent::Keyboard.new
-    params["_aug_internal"]        = Augeas::open(@data2_dir,nil, Augeas::NO_MODL_AUTOLOAD)
+    file2 = ConfigAgent::Keyboard.new( { :root_dir => @data2_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
     params["YAST_KEYBOARD"]        = "english-uk,pc104"
     params["KEYTABLE"]        	= "uk.map.gz"
 

--- a/config_agent-country/test/test_keyboard.rb
+++ b/config_agent-country/test/test_keyboard.rb
@@ -30,7 +30,7 @@ class TestKeyboard < Test::Unit::TestCase
   end
 
   def test_reading
-    file = ConfigAgent::Keyboard.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file = ConfigAgent::Keyboard.new( :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     sysconfig_keyboard = file.read ({})
     assert_equal "english-us,pc104", sysconfig_keyboard["YAST_KEYBOARD"]
     assert_equal "us.map.gz", sysconfig_keyboard["KEYTABLE"]
@@ -40,7 +40,7 @@ class TestKeyboard < Test::Unit::TestCase
 
   # write new file
   def test_write
-    file = ConfigAgent::Keyboard.new( { :root_dir => @data1_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file = ConfigAgent::Keyboard.new( :root_dir => @data1_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     params        = {
         "YAST_KEYBOARD"		=> "english-uk,pc104",
         "KEYTABLE"		=> "uk.map.gz"
@@ -52,12 +52,12 @@ class TestKeyboard < Test::Unit::TestCase
 
   # diff data/etc/sysconfig/keyboard data2/etc/sysconfig/keyboard -> change value of RC_LANG
   def test_overwrite
-    file = ConfigAgent::Keyboard.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file = ConfigAgent::Keyboard.new( :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     params = file.read({})
     assert_equal "english-us,pc104", params["YAST_KEYBOARD"]
     assert_equal "us.map.gz", params["KEYTABLE"]
 
-    file2 = ConfigAgent::Keyboard.new( { :root_dir => @data2_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file2 = ConfigAgent::Keyboard.new( :root_dir => @data2_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     params["YAST_KEYBOARD"]        = "english-uk,pc104"
     params["KEYTABLE"]        	= "uk.map.gz"
 

--- a/config_agent-country/test/test_language.rb
+++ b/config_agent-country/test/test_language.rb
@@ -30,7 +30,7 @@ class TestLanguage < Test::Unit::TestCase
   end
 
   def test_reading
-    file = ConfigAgent::Language.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file = ConfigAgent::Language.new( :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     sysconfig_language = file.read({})
     assert_equal "cs_CZ.UTF-8", sysconfig_language["RC_LANG"]
     assert_equal "", sysconfig_language["INSTALLED_LANGUAGES"]
@@ -38,7 +38,7 @@ class TestLanguage < Test::Unit::TestCase
 
   # write new file
   def test_write
-    file = ConfigAgent::Language.new( { :root_dir => @data1_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file = ConfigAgent::Language.new( :root_dir => @data1_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     params        = {
         "ROOT_USES_LANG"	=> "yes",
         "RC_LANG"		=> "en_US.UTF-8"
@@ -50,12 +50,12 @@ class TestLanguage < Test::Unit::TestCase
 
   # diff data/etc/sysconfig/language data2/etc/sysconfig/language -> change value of RC_LANG
   def test_overwrite
-    file = ConfigAgent::Language.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file = ConfigAgent::Language.new( :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     params = file.read({})
     assert_equal "cs_CZ.UTF-8", params["RC_LANG"]
     assert_equal "", params["INSTALLED_LANGUAGES"]
 
-    file2 = ConfigAgent::Language.new( { :root_dir => @data2_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    file2 = ConfigAgent::Language.new( :root_dir => @data2_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") )
     params["RC_LANG"]        	= "en_US.UTF-8"
     params["INSTALLED_LANGUAGES"]        = "cs_CZ,en_US"
 

--- a/config_agent-country/test/test_language.rb
+++ b/config_agent-country/test/test_language.rb
@@ -30,34 +30,32 @@ class TestLanguage < Test::Unit::TestCase
   end
 
   def test_reading
-    file = ConfigAgent::Language.new
-    sysconfig_language = file.read "_aug_internal" => Augeas::open(@data_dir, File.join(File.dirname(__FILE__),'..',"lens"),Augeas::NO_MODL_AUTOLOAD)
+    file = ConfigAgent::Language.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    sysconfig_language = file.read({})
     assert_equal "cs_CZ.UTF-8", sysconfig_language["RC_LANG"]
     assert_equal "", sysconfig_language["INSTALLED_LANGUAGES"]
   end
 
   # write new file
   def test_write
-    file = ConfigAgent::Language.new
+    file = ConfigAgent::Language.new( { :root_dir => @data1_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
     params        = {
-        "_aug_internal"		=> Augeas::open(@data1_dir,nil, Augeas::NO_MODL_AUTOLOAD),
         "ROOT_USES_LANG"	=> "yes",
         "RC_LANG"		=> "en_US.UTF-8"
     }
     ret = file.write params
-    assert_equal true, ret["success"]
     assert_equal nil, ret["message"]
+    assert_equal true, ret["success"]
   end
 
   # diff data/etc/sysconfig/language data2/etc/sysconfig/language -> change value of RC_LANG
   def test_overwrite
-    file = ConfigAgent::Language.new
-    params = file.read "_aug_internal" => Augeas::open(@data_dir,nil, Augeas::NO_MODL_AUTOLOAD)
+    file = ConfigAgent::Language.new( { :root_dir => @data_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
+    params = file.read({})
     assert_equal "cs_CZ.UTF-8", params["RC_LANG"]
     assert_equal "", params["INSTALLED_LANGUAGES"]
 
-    file2 = ConfigAgent::Language.new
-    params["_aug_internal"]        = Augeas::open(@data2_dir,nil, Augeas::NO_MODL_AUTOLOAD)
+    file2 = ConfigAgent::Language.new( { :root_dir => @data2_dir, :include => File.join(File.dirname(__FILE__),'..',"lens") })
     params["RC_LANG"]        	= "en_US.UTF-8"
     params["INSTALLED_LANGUAGES"]        = "cs_CZ,en_US"
 

--- a/libconfigagent/lib/config_agent/augeas_wrapper.rb
+++ b/libconfigagent/lib/config_agent/augeas_wrapper.rb
@@ -31,15 +31,16 @@ module ConfigAgent
     # * root_dir - which dir should be used as filesystem root
     #
     def initialize( params)
-        @lens      = params[ :lens]
-        @file_path = params[ :path]
-        @incl_path = params[ :include]
-        @root_dir  = params[ :root_dir]
 
-        raise ArgumentError,"Path argument must be absolut path" unless @file_path.start_with? '/'
-        # TODO: add other checks here
+      @lens      = params[ :lens]
+      @file_path = params[ :path]
+      @incl_path = params[ :include]
+      @root_dir  = params[ :root_dir]
 
-	@aug_tree = open_augeas
+      raise ArgumentError,"Path argument must be absolut path" unless @file_path.start_with? '/'
+      # TODO: add other checks here
+
+      @aug_tree = open_augeas
     end
 
     def AugeasWrapper.finalize( id)
@@ -59,7 +60,7 @@ module ConfigAgent
 
       aug.match("/files#{@file_path}/*").each do |key_path|
         key = key_path.split("/").last
-  
+
         # do not ignore comments, there are several bugs on YaST2 (e.g. comments got lost, ...)
         # TODO: configurable option?
         #      next if key.start_with? "#comment"
@@ -85,8 +86,8 @@ module ConfigAgent
       end
 
       unless aug.save
-          ret["success"] = false
-          ret["message"] = aug.get("/augeas/files#{@file_path}/error/message")
+        ret["success"] = false
+        ret["message"] = aug.get("/augeas/files#{@file_path}/error/message")
       end
 
       return ret

--- a/libconfigagent/lib/config_agent/augeas_wrapper.rb
+++ b/libconfigagent/lib/config_agent/augeas_wrapper.rb
@@ -48,7 +48,7 @@ module ConfigAgent
 
     # loads data from the augeas tree and stores them in a hash
     def serialize( params)
-      raise ArgumentError "_aug_internal not supported" if params.has_key?( "_aug_internal")
+      raise ArgumentError, "_aug_internal not supported" if params.has_key?( "_aug_internal")
 
       ret = {}
 
@@ -72,7 +72,7 @@ module ConfigAgent
 
     # loads data from given hash and stores them in the augeas tree
     def deserialize( params)
-      raise ArgumentError "_aug_internal not supported" if params.has_key?( "_aug_internal")
+      raise ArgumentError, "_aug_internal not supported" if params.has_key?( "_aug_internal")
 
       ret = {
         "success" => true

--- a/libconfigagent/lib/config_agent/augeas_wrapper.rb
+++ b/libconfigagent/lib/config_agent/augeas_wrapper.rb
@@ -1,0 +1,117 @@
+#--
+# Config Agents Framework
+#
+# Copyright (C) 2011 Novell, Inc.
+#   This library is free software; you can redistribute it and/or modify
+# it only under the terms of version 2.1 or version 3 of the GNU Lesser General Public
+# License as published by the Free Software Foundation.
+#
+#   This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+#   You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#++
+#
+require 'config_agent/file_agent'
+require 'augeas'
+
+module ConfigAgent
+
+  class AugeasWrapper < ConfigAgent::FileAgent
+
+    #
+    # known params:
+    # * lens     - which lens should be used
+    # * path     - which file should be loaded
+    # * include  - where to look for lenses additionaly to default path
+    # * root_dir - which dir should be used as filesystem root
+    #
+    def initialize( params)
+        @lens      = params[ :lens]
+        @file_path = params[ :path]
+        @incl_path = params[ :include]
+        @root_dir  = params[ :root_dir]
+
+        raise ArgumentError,"Path argument must be absolut path" unless @file_path.start_with? '/'
+        # TODO: add other checks here
+
+	@aug_tree = open_augeas
+    end
+
+    def AugeasWrapper.finalize( id)
+      @aug_tree.close if @aug_tree
+    end
+
+    # loads data from the augeas tree and stores them in a hash
+    def serialize( params)
+      raise ArgumentError "_aug_internal not supported" if params.has_key?( "_aug_internal")
+
+      ret = {}
+
+      aug = load_augeas( @aug_tree)
+
+      #FIXME report it.
+      return ret unless aug.get("/augeas/files#{@file_path}/error").nil?
+
+      aug.match("/files#{@file_path}/*").each do |key_path|
+        key = key_path.split("/").last
+  
+        # do not ignore comments, there are several bugs on YaST2 (e.g. comments got lost, ...)
+        # TODO: configurable option?
+        #      next if key.start_with? "#comment"
+
+        ret[ key] = aug.get(key_path)
+      end
+
+      return ret
+    end
+
+    # loads data from given hash and stores them in the augeas tree
+    def deserialize( params)
+      raise ArgumentError "_aug_internal not supported" if params.has_key?( "_aug_internal")
+
+      ret = {
+        "success" => true
+      }
+
+      aug = load_augeas( @aug_tree)
+
+      params.each do |key, value|
+          aug.set("/files#{@file_path}/#{key}", value)
+      end
+
+      unless aug.save
+          ret["success"] = false
+          ret["message"] = aug.get("/augeas/files#{@file_path}/error/message")
+      end
+
+      return ret
+    end
+
+  private
+
+    # opens connection to augeas
+    def open_augeas()
+      aug = Augeas::open(nil, @incl_path, Augeas::NO_MODL_AUTOLOAD)
+
+      aug.transform(:lens => @lens, :incl => @file_path)
+
+      return aug
+    end
+      
+    # read the connected file and convert it into augeas tree
+    def load_augeas( aug)
+      raise ArgumentError, "An error in arguments, cannot create augeas tree." if aug.nil?
+
+      aug.load
+
+      return aug
+    end
+
+  end
+
+end

--- a/libconfigagent/lib/config_agent/sysconfig.rb
+++ b/libconfigagent/lib/config_agent/sysconfig.rb
@@ -22,139 +22,141 @@ require 'shellwords'
 module ConfigAgent
   class Sysconfig <  AugeasWrapper
 
-      SYSCONFIG_LENS = "Shellvars.lns"
-      DEFAULT_QUOTE  = '"'
+    SYSCONFIG_LENS = "Shellvars.lns"
+    DEFAULT_QUOTE  = '"'
 
-      def initialize( params = {})
-        params[ :lens] = SYSCONFIG_LENS
+    def initialize( params = {})
+      params[ :lens] = SYSCONFIG_LENS
 
-        super( params);
+      super( params);
 
-        @orig_values = {};
-      end
+      @orig_values = {};
+    end
 
-      def read(params)
-        ret = prepare_read( serialize( params));
-      end
+    def read(params)
+      ret = prepare_read( serialize( params));
+    end
 
-      def write(params)
-        return deserialize( prepare_write( params));
-      end
+    def write(params)
+      return deserialize( prepare_write( params));
+    end
 
   private
 
-       # to get correct value it is needed to unescape too
-       # @example
-       #   VAR_1="a\"b\"c"
-       #   VAR_2='a\"b\"c'
-       #   echo $VAR_1 ---> a"b"c
-       #   echo $VAR_2 ---> a\"b\"c
-       #
-       # we do just best efford, there is more possible outputs and more shell expansions
-      STATES = [ :double_quote, :single_quote, :unquote ]
-      def unpack( string)
-        # Lets do it iterative, so when something not comform adapt it
-        # we use state machine for such task
-        state = :unquote
-        result = ''
-        1.upto(string.size) do |char_pos_p|
-          char = string[char_pos_p-1].chr
-          case state
-          when :unquote
-            if char == "'"
-              state = :single_quote
-            elsif char == '"'
-              state = :double_quote
-            elsif char == '\\'
-              state = :escape
-            else
-              result << char
-            end
-          when :single_quote
-            if char == "'"
-              state = :unquote
-            else
-              result << char
-            end
-          when :double_quote
-            if char == '"'
-              state = :unquote
-            elsif char == '\\'
-              state = :escape_double
-            else
-              result << char
-            end
-          when :escape_double
-            if ['\\',"\n",'$','`','"'].include? char
-              result << char
-            else #not special escape
-              result << '\\' << char
-            end 
+     # to get correct value it is needed to unescape too
+     # @example
+     #   VAR_1="a\"b\"c"
+     #   VAR_2='a\"b\"c'
+     #   echo $VAR_1 ---> a"b"c
+     #   echo $VAR_2 ---> a\"b\"c
+     #
+     # we do just best efford, there is more possible outputs and more shell expansions
+    STATES = [ :double_quote, :single_quote, :unquote ]
+    def unpack( string)
+      # Lets do it iterative, so when something not comform adapt it
+      # we use state machine for such task
+      state = :unquote
+      result = ''
+      1.upto(string.size) do |char_pos_p|
+        char = string[char_pos_p-1].chr
+        case state
+        when :unquote
+          if char == "'"
+            state = :single_quote
+          elsif char == '"'
             state = :double_quote
-          when :escape
+          elsif char == '\\'
+            state = :escape
+          else
             result << char
+          end
+        when :single_quote
+          if char == "'"
             state = :unquote
           else
-            raise "Invalid state. Internal Error"
+            result << char
           end
-        end
-        raise "invalid string value" if state != :unquote
-        return result
-      end
-
-      def pack( string)
-        # cannot use Shellwords::escape - augeas (current version of Shellvars.lns) 
-        # cannot process escaped space.
-        #
-        # in fact following simple substitution should be enough
-        if string.match( /[ ]/) != nil
-          result = "\"#{string.gsub(/\\\"/n, "\"").gsub(/(["])/n, "\\\\\\1")}\"" 
+        when :double_quote
+          if char == '"'
+            state = :unquote
+          elsif char == '\\'
+            state = :escape_double
+          else
+            result << char
+          end
+        when :escape_double
+          if ['\\',"\n",'$','`','"'].include? char
+            result << char
+          else #not special escape
+            result << '\\' << char
+          end 
+          state = :double_quote
+        when :escape
+          result << char
+          state = :unquote
         else
-          result = Shellwords.escape( string)
-        end        
-        return result
+          raise "Invalid state. Internal Error"
+        end
       end
 
-      # parse values loaded from the underlying file. It removes quoting and so on.
-      def prepare_read( values)
-          ret = {}
+      raise "invalid string value" if state != :unquote
 
-          values.each do |key, value|
-              @orig_values[ key] = value;
-              
-              # remove quotes from value (Shellvars.lns keeps quoting), unescape values
-              #do not unpack comments
-              ret[key] = key.start_with?("#comment") ? value : unpack(value)
-          end
+      return result
+    end
 
-          return ret
-      end
-      
-      # see prepare_read. Prepare given values into a raw state ready for writing.
-      def prepare_write( values)
-          ret = {}
+    def pack( string)
+      # cannot use Shellwords::escape - augeas (current version of Shellvars.lns) 
+      # cannot process escaped space.
+      #
+      # in fact following simple substitution should be enough
+      if string.match( /[ ]/) != nil
+        result = "\"#{string.gsub(/\\\"/n, "\"").gsub(/(["])/n, "\\\\\\1")}\"" 
+      else
+        result = Shellwords.escape( string)
+      end        
+      return result
+    end
 
-          return {} if values.nil?
+    # parse values loaded from the underlying file. It removes quoting and so on.
+    def prepare_read( values)
+      ret = {}
 
-          values.each do |key, value|
-              next if key.start_with? "_"                   # skip internal keys
-
-              if ( !@orig_values[ key].nil? && unpack( @orig_values[ key]) == value)
-                ret[ key] = @orig_values[ key]
-              elsif ( key.start_with? "#comment")
-                ret[ key] = value;
-              else
-                ret[ key] = pack( value);
-
-	        if !( ret[ key] =~ /^["'].*["']$/)
-                  ret[ key] = DEFAULT_QUOTE + ret[ key] + DEFAULT_QUOTE;
-		end 
-              end
-          end
-
-          return ret
+      values.each do |key, value|
+        @orig_values[ key] = value;
+        
+        # remove quotes from value (Shellvars.lns keeps quoting), unescape values
+        #do not unpack comments
+        ret[key] = key.start_with?("#comment") ? value : unpack(value)
       end
 
+      return ret
+    end
   
+    # see prepare_read. Prepare given values into a raw state ready for writing.
+    def prepare_write( values)
+      ret = {}
+
+      return {} if values.nil?
+
+      values.each do |key, value|
+        next if key.start_with? "_"                   # skip internal keys
+
+        if ( !@orig_values[ key].nil? && unpack( @orig_values[ key]) == value)
+          ret[ key] = @orig_values[ key]
+        elsif ( key.start_with? "#comment")
+          ret[ key] = value;
+        else
+          ret[ key] = pack( value);
+
+          if !( ret[ key] =~ /^["'].*["']$/)
+            ret[ key] = DEFAULT_QUOTE + ret[ key] + DEFAULT_QUOTE;
+          end 
+        end
+      end
+
+      return ret
+    end
+
   end
+
 end

--- a/libconfigagent/lib/config_agent/sysconfig.rb
+++ b/libconfigagent/lib/config_agent/sysconfig.rb
@@ -21,217 +21,216 @@ require 'augeas'
 require 'shellwords'
 
 module ConfigAgent
-    class Sysconfig <  ConfigAgent::FileAgent
+  class Sysconfig <  ConfigAgent::FileAgent
+    
+    SYSCONFIG_LENS = "Shellvars.lns"
+    DEFAULT_QUOTE  = '"'
 
-        SYSCONFIG_LENS = "Shellvars.lns"
-        DEFAULT_QUOTE  = '"'
-
-        def initialize path,params={}
-            raise ArgumentError,"Path argument must be absolut path" unless path.start_with? '/'
-        
-            @file_path = path
-            @orig_values = {};
-
-            @aug_tree = open_augeas
-        end
-
-        def ConfigAgent.finalize( id)
-            @aug_tree.close if @aug_tree
-        end
-
-        def read(params)
-            if( params[ "_aug_internal"])
-                @aug_tree.close
-                @aug_tree = params[ "_aug_internal"]
-            end
-
-            @aug_tree = load_augeas( @aug_tree)
-            ret = prepare_read( raw_read);
-        end
-
-        def write(params)
-            values = params;
-
-            if( params[ "_aug_internal"])
-                @aug_tree.close
-                @aug_tree = params[ "_aug_internal"]
-
-                values.delete( "_aug_internal");
-            end
-
-            @aug_tree = load_augeas( @aug_tree)
-            return raw_write( prepare_write( params));
-        end
-
-    private
-
-        def open_augeas()
-            return Augeas::open(nil, "", Augeas::NO_MODL_AUTOLOAD);
-        end
+    def initialize path,params={}
+      raise ArgumentError,"Path argument must be absolut path" unless path.start_with? '/'
       
-        def load_augeas( aug)
-            raise ArgumentError, "An error in arguments, cannot create augeas tree." if @aug_tree.nil?
+      @file_path = path
+      @orig_values = {};
 
-            aug.transform(:lens => SYSCONFIG_LENS, :incl => @file_path)
-            aug.load
+      @aug_tree = open_augeas
+    end
 
-            return aug
-        end
+    def ConfigAgent.finalize( id)
+      @aug_tree.close if @aug_tree
+    end
 
-        # to get correct value it is needed to unescape too
-        # @example
-        #   VAR_1="a\"b\"c"
-        #   VAR_2='a\"b\"c'
-        #   echo $VAR_1 ---> a"b"c
-        #   echo $VAR_2 ---> a\"b\"c
-        #
-        # we do just best efford, there is more possible outputs and more shell expansions
-        STATES = [ :double_quote, :single_quote, :unquote ]
-        def unpack( string)
-        # Lets do it iterative, so when something not comform adapt it
-        # we use state machine for such task
-            state = :unquote
-            result = ''
+    def read(params)
+      if( params[ "_aug_internal"])
+          @aug_tree.close
+          @aug_tree = params[ "_aug_internal"]
+      end
+
+      @aug_tree = load_augeas( @aug_tree)
+      ret = prepare_read( raw_read);
+    end
+
+    def write(params)
+      values = params;
+
+      if( params[ "_aug_internal"])
+        @aug_tree.close
+        @aug_tree = params[ "_aug_internal"]
+
+        values.delete( "_aug_internal");
+      end
+
+      @aug_tree = load_augeas( @aug_tree)
+      return raw_write( prepare_write( params));
+    end
+
+  private
+
+    def open_augeas()
+      return Augeas::open(nil, "", Augeas::NO_MODL_AUTOLOAD);
+    end
+      
+    def load_augeas( aug)
+      raise ArgumentError, "An error in arguments, cannot create augeas tree." if @aug_tree.nil?
+
+      aug.transform(:lens => SYSCONFIG_LENS, :incl => @file_path)
+      aug.load
+
+      return aug
+    end
+
+    # to get correct value it is needed to unescape too
+    # @example
+    #   VAR_1="a\"b\"c"
+    #   VAR_2='a\"b\"c'
+    #   echo $VAR_1 ---> a"b"c
+    #   echo $VAR_2 ---> a\"b\"c
+    #
+    # we do just best efford, there is more possible outputs and more shell expansions
+    STATES = [ :double_quote, :single_quote, :unquote ]
+    def unpack( string)
+    # Lets do it iterative, so when something not comform adapt it
+    # we use state machine for such task
+      state = :unquote
+      result = ''
         
-            1.upto(string.size) do |char_pos_p|
-                char = string[char_pos_p-1].chr
+      1.upto(string.size) do |char_pos_p|
+        char = string[char_pos_p-1].chr
           
-                case state
-                    when :unquote
-                        if char == "'"
-                            state = :single_quote
-                        elsif char == '"'
-                            state = :double_quote
-                        elsif char == '\\'
-                            state = :escape
-                        else
-                            result << char
-                        end
-                    when :single_quote
-                        if char == "'"
-                            state = :unquote
-                        else
-                            result << char
-                        end
-                    when :double_quote
-                        if char == '"'
-                            state = :unquote
-                        elsif char == '\\'
-                            state = :escape_double
-                        else
-                            result << char
-                        end
-                    when :escape_double
-                        if ['\\',"\n",'$','`','"'].include? char
-                            result << char
-                        else #not special escape
-                            result << '\\' << char
-                        end 
-                        state = :double_quote
-                    when :escape
-                        result << char
-                        state = :unquote
-                    else
-                        raise "Invalid state. Internal Error"
-                    end
-                end
-            
-            raise "invalid string value" if state != :unquote
-            
-            return result
-        end
-
-        def pack( string)
-        # cannot use Shellwords::escape - augeas (current version of Shellvars.lns) 
-        # cannot process escaped space.
-        #
-        # in fact following simple substitution should be enough
-            if string.match( /[ ]/) != nil
-                result = "\"#{string.gsub(/\\\"/n, "\"").gsub(/(["])/n, "\\\\\\1")}\"" 
+        case state
+          when :unquote
+            if char == "'"
+              state = :single_quote
+            elsif char == '"'
+              state = :double_quote
+            elsif char == '\\'
+              state = :escape
             else
-                result = Shellwords.escape( string)
-            end        
+              result << char
+            end
+          when :single_quote
+            if char == "'"
+              state = :unquote
+            else
+              result << char
+            end
+          when :double_quote
+            if char == '"'
+              state = :unquote
+            elsif char == '\\'
+              state = :escape_double
+            else
+              result << char
+            end
+          when :escape_double
+            if ['\\',"\n",'$','`','"'].include? char
+              result << char
+            else #not special escape
+              result << '\\' << char
+            end 
+            state = :double_quote
+          when :escape
+            result << char
+            state = :unquote
+          else
+            raise "Invalid state. Internal Error"
+          end
+        end
             
-            return result
-        end
+        raise "invalid string value" if state != :unquote
+            
+        return result
+    end
 
-        # returns content of underlying file as it get it.
-        def raw_read
-            ret = {}
+    def pack( string)
+    # cannot use Shellwords::escape - augeas (current version of Shellvars.lns) 
+    # cannot process escaped space.
+    #
+    # in fact following simple substitution should be enough
+      if string.match( /[ ]/) != nil
+        result = "\"#{string.gsub(/\\\"/n, "\"").gsub(/(["])/n, "\\\\\\1")}\"" 
+      else
+        result = Shellwords.escape( string)
+      end        
+            
+      return result
+    end
 
-            unless @aug_tree.get("/augeas/files#{@file_path}/error").nil?
-            #FIXME report it. TODO have universal wrapper for this (augeas serializer)
-                return ret
-            end
+    # returns content of underlying file as it get it.
+    def raw_read
+      ret = {}
 
-            @aug_tree.match("/files#{@file_path}/*").each do |key_path|
-                key = key_path.split("/").last
+      unless @aug_tree.get("/augeas/files#{@file_path}/error").nil?
+      #FIXME report it. TODO have universal wrapper for this (augeas serializer)
+        return ret
+      end
+
+      @aug_tree.match("/files#{@file_path}/*").each do |key_path|
+        key = key_path.split("/").last
   
-                # do not ignore comments, there are several bugs on YaST2 (e.g. comments got lost, ...)
-                # TODO: configurable option?
-                #      next if key.start_with? "#comment"
+        # do not ignore comments, there are several bugs on YaST2 (e.g. comments got lost, ...)
+        # TODO: configurable option?
+        #      next if key.start_with? "#comment"
 
-                ret[ key] = @aug_tree.get(key_path)
-            end
+        ret[ key] = @aug_tree.get(key_path)
+      end
 
-            return ret
-        end
+      return ret
+    end
 
-        # writes values as it gets them
-        def raw_write(params)
-            ret = {
-                "success" => true
-            }
+    # writes values as it gets them
+    def raw_write(params)
+      ret = {
+        "success" => true
+      }
 
-            params.each do |key, value|
-                @aug_tree.set("/files#{@file_path}/#{key}", value)
-            end
+      params.each do |key, value|
+        @aug_tree.set("/files#{@file_path}/#{key}", value)
+      end
 
-            unless @aug_tree.save
-                ret["success"] = false
-                ret["message"] = @aug_tree.get("/augeas/files#{@file_path}/error/message")
-            end
+      unless @aug_tree.save
+        ret["success"] = false
+        ret["message"] = @aug_tree.get("/augeas/files#{@file_path}/error/message")
+      end
 
-            return ret
-        end
+      return ret
+    end
 
-        # parse values loaded from the underlying file. It removes quoting and so on.
-        def prepare_read( values)
-            ret = {}
+    # parse values loaded from the underlying file. It removes quoting and so on.
+    def prepare_read( values)
+      ret = {}
 
-            values.each do |key, value|
-                @orig_values[ key] = value;
+      values.each do |key, value|
+        @orig_values[ key] = value;
               
-                # remove quotes from value (Shellvars.lns keeps quoting), unescape values
-                #do not unpack comments
-                ret[key] = key.start_with?("#comment") ? value : unpack(value)
-            end
+        # remove quotes from value (Shellvars.lns keeps quoting), unescape values
+        #do not unpack comments
+        ret[key] = key.start_with?("#comment") ? value : unpack(value)
+      end
 
-            return ret
-        end
+      return ret
+    end
       
-        # see prepare_read. Prepare given values into a raw state ready for writing.
-        def prepare_write( values)
-            ret = {}
+    # see prepare_read. Prepare given values into a raw state ready for writing.
+    def prepare_write( values)
+      ret = {}
 
-            return {} if values.nil?
+      return {} if values.nil?
 
-            values.each do |key, value|
-                if ( !@orig_values[ key].nil? && unpack( @orig_values[ key]) == value)
-                    ret[ key] = @orig_values[ key]
-                elsif ( key.start_with? "#comment")
-                    ret[ key] = value;
-                else
-                    ret[ key] = pack( value);
+      values.each do |key, value|
+        if ( !@orig_values[ key].nil? && unpack( @orig_values[ key]) == value)
+          ret[ key] = @orig_values[ key]
+        elsif ( key.start_with? "#comment")
+          ret[ key] = value;
+        else
+          ret[ key] = pack( value);
 
-	            if !( ret[ key] =~ /^["'].*["']$/)
-                        ret[ key] = DEFAULT_QUOTE + ret[ key] + DEFAULT_QUOTE;
-		    end 
-                end
-            end
-
-            return ret
+	      if !( ret[ key] =~ /^["'].*["']$/)
+            ret[ key] = DEFAULT_QUOTE + ret[ key] + DEFAULT_QUOTE;
+		  end 
         end
+      end
 
-    end     # class
+      return ret
+    end
+  end     # class
 end

--- a/libconfigagent/lib/config_agent/sysconfig.rb
+++ b/libconfigagent/lib/config_agent/sysconfig.rb
@@ -46,13 +46,17 @@ module ConfigAgent
             end
 
             @aug_tree = load_augeas( @aug_tree)
-            ret = prepare_read( raw_read( params));
+            ret = prepare_read( raw_read);
         end
 
         def write(params)
+            values = params;
+
             if( params[ "_aug_internal"])
                 @aug_tree.close
                 @aug_tree = params[ "_aug_internal"]
+
+                values.delete( "_aug_internal");
             end
 
             @aug_tree = load_augeas( @aug_tree)
@@ -152,7 +156,7 @@ module ConfigAgent
         end
 
         # returns content of underlying file as it get it.
-        def raw_read(params)
+        def raw_read
             ret = {}
 
             unless @aug_tree.get("/augeas/files#{@file_path}/error").nil?
@@ -183,7 +187,7 @@ module ConfigAgent
                 @aug_tree.set("/files#{@file_path}/#{key}", value)
             end
 
-            unless aug.save
+            unless @aug_tree.save
                 ret["success"] = false
                 ret["message"] = @aug_tree.get("/augeas/files#{@file_path}/error/message")
             end
@@ -213,8 +217,6 @@ module ConfigAgent
             return {} if values.nil?
 
             values.each do |key, value|
-                next if key.start_with? "_"                   # skip internal keys
-
                 if ( !@orig_values[ key].nil? && unpack( @orig_values[ key]) == value)
                     ret[ key] = @orig_values[ key]
                 elsif ( key.start_with? "#comment")

--- a/libconfigagent/lib/config_agent/sysconfig.rb
+++ b/libconfigagent/lib/config_agent/sysconfig.rb
@@ -21,213 +21,215 @@ require 'augeas'
 require 'shellwords'
 
 module ConfigAgent
-  class Sysconfig <  ConfigAgent::FileAgent
+    class Sysconfig <  ConfigAgent::FileAgent
 
-      SYSCONFIG_LENS = "Shellvars.lns"
-      DEFAULT_QUOTE  = '"'
+        SYSCONFIG_LENS = "Shellvars.lns"
+        DEFAULT_QUOTE  = '"'
 
-      def initialize path,params={}
-        raise ArgumentError,"Path argument must be absolut path" unless path.start_with? '/'
-        @file_path = path
-        @orig_values = {};
+        def initialize path,params={}
+            raise ArgumentError,"Path argument must be absolut path" unless path.start_with? '/'
+        
+            @file_path = path
+            @orig_values = {};
 
-	@aug_tree = open_augeas
-      end
+            @aug_tree = open_augeas
+        end
 
-      def ConfigAgent.finalize( id)
-        @aug_tree.close if @aug_tree
-      end
+        def ConfigAgent.finalize( id)
+            @aug_tree.close if @aug_tree
+        end
 
-      def read(params)
-	if( params[ "_aug_internal"])
-          @aug_tree.close
-	  @aug_tree = params[ "_aug_internal"]
-	end
+        def read(params)
+            if( params[ "_aug_internal"])
+                @aug_tree.close
+                @aug_tree = params[ "_aug_internal"]
+            end
 
-        @aug_tree = load_augeas( @aug_tree)
-        ret = prepare_read( raw_read( params));
-      end
+            @aug_tree = load_augeas( @aug_tree)
+            ret = prepare_read( raw_read( params));
+        end
 
-      def write(params)
-	if( params[ "_aug_internal"])
-          @aug_tree.close
-	  @aug_tree = params[ "_aug_internal"]
-	end
+        def write(params)
+            if( params[ "_aug_internal"])
+                @aug_tree.close
+                @aug_tree = params[ "_aug_internal"]
+            end
 
-        @aug_tree = load_augeas( @aug_tree)
-        return raw_write( prepare_write( params));
-      end
+            @aug_tree = load_augeas( @aug_tree)
+            return raw_write( prepare_write( params));
+        end
 
-  private
+    private
 
-      def open_augeas()
-        return Augeas::open(nil, "", Augeas::NO_MODL_AUTOLOAD);
-      end
+        def open_augeas()
+            return Augeas::open(nil, "", Augeas::NO_MODL_AUTOLOAD);
+        end
       
-      def load_augeas( aug)
-	  raise ArgumentError, "An error in arguments, cannot create augeas tree." if @aug_tree.nil?
+        def load_augeas( aug)
+            raise ArgumentError, "An error in arguments, cannot create augeas tree." if @aug_tree.nil?
 
-          aug.transform(:lens => SYSCONFIG_LENS, :incl => @file_path)
-          aug.load
+            aug.transform(:lens => SYSCONFIG_LENS, :incl => @file_path)
+            aug.load
 
-          return aug
-      end
+            return aug
+        end
 
-       # to get correct value it is needed to unescape too
-       # @example
-       #   VAR_1="a\"b\"c"
-       #   VAR_2='a\"b\"c'
-       #   echo $VAR_1 ---> a"b"c
-       #   echo $VAR_2 ---> a\"b\"c
-       #
-       # we do just best efford, there is more possible outputs and more shell expansions
-      STATES = [ :double_quote, :single_quote, :unquote ]
-      def unpack( string)
+        # to get correct value it is needed to unescape too
+        # @example
+        #   VAR_1="a\"b\"c"
+        #   VAR_2='a\"b\"c'
+        #   echo $VAR_1 ---> a"b"c
+        #   echo $VAR_2 ---> a\"b\"c
+        #
+        # we do just best efford, there is more possible outputs and more shell expansions
+        STATES = [ :double_quote, :single_quote, :unquote ]
+        def unpack( string)
         # Lets do it iterative, so when something not comform adapt it
         # we use state machine for such task
-        state = :unquote
-        result = ''
-        1.upto(string.size) do |char_pos_p|
-          char = string[char_pos_p-1].chr
-          case state
-          when :unquote
-            if char == "'"
-              state = :single_quote
-            elsif char == '"'
-              state = :double_quote
-            elsif char == '\\'
-              state = :escape
-            else
-              result << char
-            end
-          when :single_quote
-            if char == "'"
-              state = :unquote
-            else
-              result << char
-            end
-          when :double_quote
-            if char == '"'
-              state = :unquote
-            elsif char == '\\'
-              state = :escape_double
-            else
-              result << char
-            end
-          when :escape_double
-            if ['\\',"\n",'$','`','"'].include? char
-              result << char
-            else #not special escape
-              result << '\\' << char
-            end 
-            state = :double_quote
-          when :escape
-            result << char
             state = :unquote
-          else
-            raise "Invalid state. Internal Error"
-          end
+            result = ''
+        
+            1.upto(string.size) do |char_pos_p|
+                char = string[char_pos_p-1].chr
+          
+                case state
+                    when :unquote
+                        if char == "'"
+                            state = :single_quote
+                        elsif char == '"'
+                            state = :double_quote
+                        elsif char == '\\'
+                            state = :escape
+                        else
+                            result << char
+                        end
+                    when :single_quote
+                        if char == "'"
+                            state = :unquote
+                        else
+                            result << char
+                        end
+                    when :double_quote
+                        if char == '"'
+                            state = :unquote
+                        elsif char == '\\'
+                            state = :escape_double
+                        else
+                            result << char
+                        end
+                    when :escape_double
+                        if ['\\',"\n",'$','`','"'].include? char
+                            result << char
+                        else #not special escape
+                            result << '\\' << char
+                        end 
+                        state = :double_quote
+                    when :escape
+                        result << char
+                        state = :unquote
+                    else
+                        raise "Invalid state. Internal Error"
+                    end
+                end
+            
+            raise "invalid string value" if state != :unquote
+            
+            return result
         end
-        raise "invalid string value" if state != :unquote
-        return result
-      end
 
-      def pack( string)
+        def pack( string)
         # cannot use Shellwords::escape - augeas (current version of Shellvars.lns) 
         # cannot process escaped space.
         #
         # in fact following simple substitution should be enough
-        if string.match( /[ ]/) != nil
-          result = "\"#{string.gsub(/\\\"/n, "\"").gsub(/(["])/n, "\\\\\\1")}\"" 
-        else
-          result = Shellwords.escape( string)
-        end        
-        return result
-      end
+            if string.match( /[ ]/) != nil
+                result = "\"#{string.gsub(/\\\"/n, "\"").gsub(/(["])/n, "\\\\\\1")}\"" 
+            else
+                result = Shellwords.escape( string)
+            end        
+            
+            return result
+        end
 
-      # returns content of underlying file as it get it.
-      def raw_read(params)
-          ret = {}
+        # returns content of underlying file as it get it.
+        def raw_read(params)
+            ret = {}
 
-          unless @aug_tree.get("/augeas/files#{@file_path}/error").nil?
+            unless @aug_tree.get("/augeas/files#{@file_path}/error").nil?
             #FIXME report it. TODO have universal wrapper for this (augeas serializer)
-              return ret
-          end
+                return ret
+            end
 
-          @aug_tree.match("/files#{@file_path}/*").each do |key_path|
-              key = key_path.split("/").last
-  # do not ignore comments, there are several bugs on YaST2 (e.g. comments got lost, ...)
-  # TODO: configurable option?
-  #      next if key.start_with? "#comment"
-
-              ret[ key] = @aug_tree.get(key_path)
-          end
-
-          return ret
-      end
-
-      # writes values as it gets them
-      def raw_write(params)
-          ret = {
-            "success" => true
-          }
-
-          aug = @aug_tree
-
-          params.each do |key, value|
-              aug.set("/files#{@file_path}/#{key}", value)
-          end
-
-          unless aug.save
-              ret["success"] = false
-              ret["message"] = aug.get("/augeas/files#{@file_path}/error/message")
-          end
-
-          aug.close
-          
-          return ret
-      end
-
-      # parse values loaded from the underlying file. It removes quoting and so on.
-      def prepare_read( values)
-          ret = {}
-
-          values.each do |key, value|
-              @orig_values[ key] = value;
-              
-              # remove quotes from value (Shellvars.lns keeps quoting), unescape values
-              #do not unpack comments
-              ret[key] = key.start_with?("#comment") ? value : unpack(value)
-          end
-
-          return ret
-      end
-      
-      # see prepare_read. Prepare given values into a raw state ready for writing.
-      def prepare_write( values)
-          ret = {}
-
-          return {} if values.nil?
-
-          values.each do |key, value|
-              next if key.start_with? "_"                   # skip internal keys
-
-              if ( !@orig_values[ key].nil? && unpack( @orig_values[ key]) == value)
-                ret[ key] = @orig_values[ key]
-              elsif ( key.start_with? "#comment")
-                ret[ key] = value;
-              else
-                ret[ key] = pack( value);
-
-	        if !( ret[ key] =~ /^["'].*["']$/)
-                  ret[ key] = DEFAULT_QUOTE + ret[ key] + DEFAULT_QUOTE;
-		end 
-              end
-          end
-
-          return ret
-      end
-
+            @aug_tree.match("/files#{@file_path}/*").each do |key_path|
+                key = key_path.split("/").last
   
-  end
+                # do not ignore comments, there are several bugs on YaST2 (e.g. comments got lost, ...)
+                # TODO: configurable option?
+                #      next if key.start_with? "#comment"
+
+                ret[ key] = @aug_tree.get(key_path)
+            end
+
+            return ret
+        end
+
+        # writes values as it gets them
+        def raw_write(params)
+            ret = {
+                "success" => true
+            }
+
+            params.each do |key, value|
+                @aug_tree.set("/files#{@file_path}/#{key}", value)
+            end
+
+            unless aug.save
+                ret["success"] = false
+                ret["message"] = @aug_tree.get("/augeas/files#{@file_path}/error/message")
+            end
+
+            return ret
+        end
+
+        # parse values loaded from the underlying file. It removes quoting and so on.
+        def prepare_read( values)
+            ret = {}
+
+            values.each do |key, value|
+                @orig_values[ key] = value;
+              
+                # remove quotes from value (Shellvars.lns keeps quoting), unescape values
+                #do not unpack comments
+                ret[key] = key.start_with?("#comment") ? value : unpack(value)
+            end
+
+            return ret
+        end
+      
+        # see prepare_read. Prepare given values into a raw state ready for writing.
+        def prepare_write( values)
+            ret = {}
+
+            return {} if values.nil?
+
+            values.each do |key, value|
+                next if key.start_with? "_"                   # skip internal keys
+
+                if ( !@orig_values[ key].nil? && unpack( @orig_values[ key]) == value)
+                    ret[ key] = @orig_values[ key]
+                elsif ( key.start_with? "#comment")
+                    ret[ key] = value;
+                else
+                    ret[ key] = pack( value);
+
+	            if !( ret[ key] =~ /^["'].*["']$/)
+                        ret[ key] = DEFAULT_QUOTE + ret[ key] + DEFAULT_QUOTE;
+		    end 
+                end
+            end
+
+            return ret
+        end
+
+    end     # class
 end

--- a/libconfigagent/test/test_sysconfig.rb
+++ b/libconfigagent/test/test_sysconfig.rb
@@ -62,7 +62,7 @@ TEST_STABILITY_IN_FILE = "input"
     agent= ConfigAgent::Sysconfig.new( @data + TEST_STABILITY_IN_FILE)
     params = agent.read({})
 
-    assert_equal agent.send( :raw_read, {}), agent.send( :prepare_write, params)
+    assert_equal agent.send( :raw_read), agent.send( :prepare_write, params)
   end
 
   def test_new_value_write

--- a/libconfigagent/test/test_sysconfig.rb
+++ b/libconfigagent/test/test_sysconfig.rb
@@ -49,7 +49,7 @@ TEST_STABILITY_IN_FILE = "input"
   end
 
   def test_quoting
-    agent = ConfigAgent::Sysconfig.new "/dummy"
+    agent = ConfigAgent::Sysconfig.new( { :path => "/dummy" })
     TEST_UNQUOTING_MAP.each do |test,result|
       assert_equal result,agent.send(:unpack,test)
     end
@@ -59,14 +59,14 @@ TEST_STABILITY_IN_FILE = "input"
   end
 
   def test_stability
-    agent= ConfigAgent::Sysconfig.new( @data + TEST_STABILITY_IN_FILE)
+    agent= ConfigAgent::Sysconfig.new( { :path => @data + TEST_STABILITY_IN_FILE })
     params = agent.read({})
 
-    assert_equal agent.send( :raw_read, {}), agent.send( :prepare_write, params)
+    assert_equal agent.send( :serialize, {}), agent.send( :prepare_write, params)
   end
 
   def test_new_value_write
-    agent = ConfigAgent::Sysconfig.new( "/dummy")
+    agent = ConfigAgent::Sysconfig.new( { :path => "/dummy" })
     q = ConfigAgent::Sysconfig::DEFAULT_QUOTE
     params = { "KEY" => "VALUE" }
     expected = { "KEY" => q + "VALUE" + q }

--- a/libconfigagent/test/test_sysconfig.rb
+++ b/libconfigagent/test/test_sysconfig.rb
@@ -64,20 +64,18 @@ TEST_WORKING_DIR = "/tmp/"
     test_file  = TEST_WORKING_DIR + TEST_STABILITY_IN_FILE
     orig_file = @data + TEST_STABILITY_IN_FILE
 
-    res = system( "cp #{orig_file} #{test_file}")
-
-    assert( res)
+    FileUtils.cp( orig_file, test_file)
 
     # perform the test
     agent = ConfigAgent::Sysconfig.new( { :path => test_file })
 
     agent.write( agent.read({}))
-    res = system( "diff #{test_file} #{orig_file}")
+    res = FileUtils.compare_file( test_file, orig_file)
 
     assert( res)
 
     # cleanup
-    system( "rm #{test_file}")
+    FileUtils.rm( test_file)
   end
 
   def test_new_value_write

--- a/libconfigagent/test/test_sysconfig.rb
+++ b/libconfigagent/test/test_sysconfig.rb
@@ -42,6 +42,7 @@ TEST_QUOTING_MAP = {
 }
 
 TEST_STABILITY_IN_FILE = "input"
+TEST_WORKING_DIR = "/tmp/"
 
   def setup
     file_path = File.expand_path( __FILE__)
@@ -59,10 +60,24 @@ TEST_STABILITY_IN_FILE = "input"
   end
 
   def test_stability
-    agent= ConfigAgent::Sysconfig.new( { :path => @data + TEST_STABILITY_IN_FILE })
-    params = agent.read({})
+    # prepare test input
+    test_file  = TEST_WORKING_DIR + TEST_STABILITY_IN_FILE
+    orig_file = @data + TEST_STABILITY_IN_FILE
 
-    assert_equal agent.send( :serialize, {}), agent.send( :prepare_write, params)
+    res = system( "cp #{orig_file} #{test_file}")
+
+    assert( res)
+
+    # perform the test
+    agent = ConfigAgent::Sysconfig.new( { :path => test_file })
+
+    agent.write( agent.read({}))
+    res = system( "diff #{test_file} #{orig_file}")
+
+    assert( res)
+
+    # cleanup
+    system( "rm #{test_file}")
   end
 
   def test_new_value_write


### PR DESCRIPTION
I've separated augeas handling from sysconfig parsing as a first step towards in creating a generic class for handling augeas trees.

I've removed _aug_internal flag. It breaks encapsulation and was used in tests only. Moreover, it added complexity into handling proper values. The functionality was replaced by extending sysconfig's (augeas wrapper's) initialize method.
